### PR TITLE
Fixing bad crates.io links

### DIFF
--- a/src/start/install.md
+++ b/src/start/install.md
@@ -5,7 +5,7 @@ Install the Rhai Crate
 
 In order to use Rhai in a project, the Rhai crate must first be made a dependency.
 
-The easiest way is to install the Rhai crate from [`crates.io`](https:/crates.io/crates/rhai/),
+The easiest way is to install the Rhai crate from [`crates.io`](https://crates.io/crates/rhai/),
 starting by looking up the latest version and adding this line under `dependencies` in the project's `Cargo.toml`:
 
 ```toml
@@ -13,14 +13,14 @@ starting by looking up the latest version and adding this line under `dependenci
 rhai = "{{version}}"    # assuming {{version}} is the latest version
 ```
 
-Or to automatically use the latest released crate version on [`crates.io`](https:/crates.io/crates/rhai/):
+Or to automatically use the latest released crate version on [`crates.io`](https://crates.io/crates/rhai/):
 
 ```toml
 [dependencies]
 rhai = "*"
 ```
 
-Crate versions are released on [`crates.io`](https:/crates.io/crates/rhai/) infrequently,
+Crate versions are released on [`crates.io`](https://crates.io/crates/rhai/) infrequently,
 so to track the latest features, enhancements and bug fixes, pull directly from
 [GitHub](https://github.com/rhaiscript/rhai):
 


### PR DESCRIPTION
Noticed a couple of these links aren't working.

FYI, you should add `hacktoberfest` label to this repo.