### PR TITLE
Fix link to GitHub repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Configuration Settings
 
 Settings are stored in `src/context.json`:
 
-| Setting    | Description                                                                             |
-| ---------- | --------------------------------------------------------------------------------------- |
-| `version`  | version of Rhai                                                                         |
-| `repoHome` | points to the [root of the GitHub repo](https://github.com/rhaiscript/rhai/blob/master) |
-| `rootUrl`  | sub-directory for _The Book_, e.g. `/book`                                              |
+| Setting    | Description                                                                 |
+| ---------- | ----------------------------------------------------------------------------|
+| `version`  | version of Rhai                                                             |
+| `repoHome` | points to the [root of the GitHub repo](https://github.com/rhaiscript/rhai) |
+| `rootUrl`  | sub-directory for _The Book_, e.g. `/book`                                  |

--- a/src/context.json
+++ b/src/context.json
@@ -1,6 +1,6 @@
 {
 	"version": "1.5.0",
-	"repoHome": "https://github.com/rhaiscript/rhai/blob/master",
+	"repoHome": "https://github.com/rhaiscript/rhai",
 	"rootUrl": "",
 	"rootUrlX": "/book",
 	"rootUrlXX": "/book/vnext"


### PR DESCRIPTION
In `README.md` the link to `root of the GitHub repo` was resulting in 404. An alternative to `https://github.com/rhaiscript/rhai` would be `https://github.com/rhaiscript/rhai/tree/main`. I chose the former but am indifferent about it.

It also seems that `rootUrl` is not set properly for https://rhai.rs/book/. All of the links which link to book internal material result in 404.

