### PR TITLE
Fixed a link to scripts/for3.rhai

### DIFF
--- a/src/start/examples/scripts.md
+++ b/src/start/examples/scripts.md
@@ -16,7 +16,7 @@ There are also a number of examples scripts that showcase Rhai's features, all i
 | [`doc-comments.rhai`]({{repoHome}}/scripts/doc-comments.rhai)     | [doc-comments] example                                                                        |
 | [`for1.rhai`]({{repoHome}}/scripts/for1.rhai)                     | [`for`] loops                                                                                 |
 | [`for2.rhai`]({{repoHome}}/scripts/for2.rhai)                     | [`for`] loops with [array] iterations                                                         |
-| [`for3.rhai`]({{repoHome}}/scripts/for2.rhai)                     | [`for`] loops with [closures]                                                                 |
+| [`for3.rhai`]({{repoHome}}/scripts/for3.rhai)                     | [`for`] loops with [closures]                                                                 |
 | [`function_decl1.rhai`]({{repoHome}}/scripts/function_decl1.rhai) | a [function] without parameters                                                               |
 | [`function_decl2.rhai`]({{repoHome}}/scripts/function_decl2.rhai) | a [function] with two parameters                                                              |
 | [`function_decl3.rhai`]({{repoHome}}/scripts/function_decl3.rhai) | a [function] with many parameters                                                             |


### PR DESCRIPTION
1. Fixed a link to scripts/for3.rhai.

2. Not "fixed" in this PR:
The code of this script doesn't reflect its description "for loops with closures". The main/first interpretation of such a description, especially for Rust or other closure-friendly language users, is: a loop (over something iterable) that invokes a closure that receives an item from that iterable (like with [`Iterator::for_each`](https://doc.rust-lang.org/nightly/core/iter/trait.Iterator.html#method.for_each)).

If that (applying a closure to iterated items) is not idiomatic/easy/out-of-the-box, that's OK (even though it's not obvious, not even after reading the Book and using Rhai for several days). But (either way), this description + example pair is still confusing.

Yes, you do imply plural ("s" in "closures"), but the use case in the example still goes against the simplest interpretation of the descriptions.

Thank you for Rhai and the book.
Enjoy Rust.
(minor update: `each` --> `for_each` - I clearly haven't coded in Rust for a week...)