### PR TITLE
Fix pluralization of APIs

### DIFF
--- a/src/engine/eval-context.md
+++ b/src/engine/eval-context.md
@@ -3,7 +3,7 @@
 
 {{#include ../links.md}}
 
-Many functions in advanced API's contain a parameter of type `EvalContext` in order to allow the
+Many functions in advanced APIs contain a parameter of type `EvalContext` in order to allow the
 current evaluation state to be accessed and/or modified.
 
 `EvalContext` encapsulates the current _evaluation context_ and exposes the following methods.

--- a/src/engine/metadata/definitions.md
+++ b/src/engine/metadata/definitions.md
@@ -3,7 +3,7 @@ Generate Definition Files for Language Server
 
 {{#include ../../links.md}}
 
-Rhai's [language server][lsp] works with IDE's to provide integrated support for the Rhai scripting language.
+Rhai's [language server][lsp] works with IDEs to provide integrated support for the Rhai scripting language.
 
 Functions and [modules] registered with an [`Engine`] can output their [metadata][functions metadata]
 into _definition files_ which are used by the [language server][lsp].

--- a/src/language/ranges.md
+++ b/src/language/ranges.md
@@ -42,9 +42,9 @@ Ranges are commonly used in the following scenarios.
 | [`switch`] expressions     | `switch n { 0..100 => ... }`            |
 | [Bit-fields] access        | `let x = n[2..6];`                      |
 | Bits iteration             | `for bit in n.bits(2..=9) { ... }`      |
-| [Array] range-based API's  | `array.extract(2..8)`                   |
-| [BLOB] range-based API's   | `blob.parse_le_int(4..8)`               |
-| [String] range-based API's | `string.sub_string(4..=12)`             |
+| [Array] range-based APIs   | `array.extract(2..8)`                   |
+| [BLOB] range-based APIs    | `blob.parse_le_int(4..8)`               |
+| [String] range-based APIs  | `string.sub_string(4..=12)`             |
 | [Characters] iteration     | `for ch in string.bits(4..=12) { ... }` |
 | [Custom types]             | `my_obj.action(3..=15, "foo");`         |
 

--- a/src/patterns/events.md
+++ b/src/patterns/events.md
@@ -138,7 +138,7 @@ impl Handler {
     pub fn new(path: impl Into<PathBuf>) -> Self {
         let mut engine = Engine::new();
 
-        // Register custom types and API's
+        // Register custom types and APIs
         engine.register_type_with_name::<TestStruct>("TestStruct")
               .register_global_module(exported_module!(test_struct_api).into());
 

--- a/src/ref/ranges.md
+++ b/src/ref/ranges.md
@@ -36,9 +36,9 @@ Ranges are commonly used in the following scenarios.
 | [`switch`](switch.md) expressions            | `switch n { 0..100 => ... }`            |
 | [Bit-fields](bit-fields.md) access           | `let x = n[2..6];`                      |
 | Bits iteration                               | `for bit in n.bits(2..=9) { ... }`      |
-| [Array](arrays.md) range-based API's         | `array.extract(2..8)`                   |
-| [BLOB](blobs.md) range-based API's           | `blob.parse_le_int(4..8)`               |
-| [String](strings-chars.md) range-based API's | `string.sub_string(4..=12)`             |
+| [Array](arrays.md) range-based APIs          | `array.extract(2..8)`                   |
+| [BLOB](blobs.md) range-based APIs            | `blob.parse_le_int(4..8)`               |
+| [String](strings-chars.md) range-based APIs  | `string.sub_string(4..=12)`             |
 | [Characters](strings-chars.md) iteration     | `for ch in string.bits(4..=12) { ... }` |
 
 

--- a/src/rust/context-restore.md
+++ b/src/rust/context-restore.md
@@ -14,7 +14,7 @@ A reconstructed [`NativeCallContext`] acts almost the same as the original insta
 to suspend the evaluation of a script, and to continue at a later time with a new
 [`NativeCallContext`].
 
-Doing so requires the [`internals`] feature to access internal API's.
+Doing so requires the [`internals`] feature to access internal APIs.
 
 ### Step 1: Store `NativeCallContext` data
 

--- a/src/rust/derive-custom-type.md
+++ b/src/rust/derive-custom-type.md
@@ -52,8 +52,8 @@ The `rhai_type` attribute, with options, can be added to the fields of the type 
 | `readonly` |    field    |      _none_       | only auto-generate getter, no setter; cannot be used with `set`.                                                         |
 |   `get`    |    field    |   function path   | use this getter function (with `&self`) instead of the auto-generated getter; if `get_mut` is also set, this is ignored. |
 | `get_mut`  |    field    |   function path   | use this getter function (with `&mut self`) instead of the auto-generated getter.                                        |
-|   `set`    |    field    |   function path   | use this setter function instead of the auto-generated setter; cannot be used with `readonly`.                           |
-|  `extra`   |    type     |   function path   | call this function after building the type to add additional API's                                                       |
+| `set`      |    field    |   function path   | use this setter function instead of the auto-generated setter; cannot be used with `readonly`.                           |
+| `extra`    |    type     |   function path   | call this function after building the type to add additional APIs                                                        |
 
 ### Function signatures
 
@@ -103,7 +103,7 @@ pub struct ABC(
 
 #[derive(Default, Clone)]
 #[derive(CustomType)]                   // <- auto-implement 'CustomType'
-#[rhai_type(name = "MyFoo", extra = Self::build_extra)] // <- call this type 'MyFoo' and use 'build_extra' to add additional API's
+#[rhai_type(name = "MyFoo", extra = Self::build_extra)] // <- call this type 'MyFoo' and use 'build_extra' to add additional APIs
 pub struct Foo {
     #[rhai_type(skip)]                  // <- field not included
     dummy: i64,
@@ -139,7 +139,7 @@ impl Foo {
         };
     }
 
-    /// Additional API's
+    /// Additional APIs
     fn build_extra(builder: &mut TypeBuilder<Self>) {
         // Register constructor function
         builder.with_fn("new_foo", || Self::default());

--- a/src/rust/disable-custom.md
+++ b/src/rust/disable-custom.md
@@ -9,4 +9,4 @@ The [`no_object`] feature disables support for [custom types] including:
 
 * [object maps] and the [`Map`] type,
 
-* the `register_get`, `register_set` and `register_get_set` API's for [`Engine`]
+* the `register_get`, `register_set` and `register_get_set` APIs for [`Engine`]

--- a/src/rust/methods.md
+++ b/src/rust/methods.md
@@ -26,7 +26,7 @@ impl TestStruct {
 
 let mut engine = Engine::new();
 
-// Most Engine API's can be chained up.
+// Most Engine APIs can be chained up.
 engine.register_type_with_name::<TestStruct>("TestStruct")
       .register_fn("new_ts", TestStruct::new)
       .register_fn("update", TestStruct::update);

--- a/src/safety/index.md
+++ b/src/safety/index.md
@@ -102,7 +102,7 @@ is a central design goal &ndash; Rhai provides a [_Don't
 Panic_](https://en.wikipedia.org/wiki/Phrases_from_The_Hitchhiker%27s_Guide_to_the_Galaxy#Don't_Panic)
 guarantee.
 
-When using Rhai, any panic outside of API's with explicitly documented panic conditions is
+When using Rhai, any panic outside of APIs with explicitly documented panic conditions is
 considered a bug in Rhai and should be reported as such.
 
 ```admonish tip.small "OK, panic anyway"

--- a/src/start/builds/wasm.md
+++ b/src/start/builds/wasm.md
@@ -18,7 +18,7 @@ among other places.
 ```admonish warning "Unavailable features"
 
 When building for WASM, certain features will not be available,
-such as the script file API's and loading [modules] from external script files.
+such as the script file APIs and loading [modules] from external script files.
 ```
 
 ```admonish example "Sample"


### PR DESCRIPTION
The correct pluralization of API is "APIs", not "API's" (which is possessive).